### PR TITLE
Fix PandasAI import and add missing dependency

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,8 +2,9 @@ import os
 from typing import List, Any, Optional
 
 import pandas as pd
-from pandasai import PandasAI
+from pandasai import SmartDataframe
 from pandasai.llm.openai import OpenAI
+from pandasai.schemas.df_config import Config
 import firebase_admin
 from firebase_admin import credentials, firestore
 
@@ -39,8 +40,9 @@ def fetch_sales_data_csv(path: str) -> pd.DataFrame:
 def analyze_with_pandasai(question: str, df: pd.DataFrame) -> str:
     """Use PandasAI to answer question about the DataFrame."""
     llm = OpenAI(api_token=os.environ.get("OPENAI_API_KEY"))
-    pandas_ai = PandasAI(llm)
-    return pandas_ai.run(df, prompt=question)
+    config = Config(llm=llm)
+    smart_df = SmartDataframe(df, config=config)
+    return smart_df.chat(question)
 
 
 def query_llm(question: str) -> str:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pandasai
 openai
 firebase-admin
 Flask
+pyyaml


### PR DESCRIPTION
## Summary
- update usage to SmartDataframe with new Config/LLM API
- add `pyyaml` to requirements

## Testing
- `pip install --only-binary=:all: -r requirements.txt`
- `pip install --only-binary=:all: pyyaml`
- `python app.py <<'EOF'
平均販売個数は？
EOF` *(fails: Connection error due to blocked OpenAI API)*

------
https://chatgpt.com/codex/tasks/task_e_684d0994a01c8326847f2c289caf8cad