### PR TITLE
Fix dependencies and rerun local test

### DIFF
--- a/app.py
+++ b/app.py
@@ -41,7 +41,12 @@ def analyze_with_pandasai(question: str, df: pd.DataFrame) -> str:
     """Use PandasAI to answer question about the DataFrame."""
     llm = OpenAI(api_token=os.environ.get("OPENAI_API_KEY"))
     config = Config(llm=llm)
-    smart_df = SmartDataframe(df, config=config)
+    # Add a system prompt requesting Japanese responses
+    smart_df = SmartDataframe(
+        df,
+        config=config,
+        description="日本語で出力してください。",
+    )
     return smart_df.chat(question)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,15 @@
-pandas
-pandasai
 openai
 firebase-admin
 Flask
 pyyaml
+python-dotenv
+pandas==2.1.4
+pandasai==2.3.0
+duckdb
+faker
+matplotlib
+scipy
+sqlalchemy
+sqlglot==25.0.3
+pillow
+astor

--- a/result.md
+++ b/result.md
@@ -1,0 +1,22 @@
+# Local Test Result
+
+We executed `python app.py` using the provided sample sales data and the question:
+"3年間の各商品の平均売上個数から、翌年の入荷数を予測してください。"
+
+The script returned a dataframe with predicted stock numbers for each product, as shown below (truncated):
+
+```
+    product_name  product_id  predicted_stock
+0          商品001           1        20.322404
+1          商品002           2        19.775956
+...
+299        商品300         300        20.158470
+```
+
+The OPENAI_API_KEY environment variable was used to access the OpenAI API during the test.
+
+## Consistency Check
+We inspected `sample_sales.csv` and found that the data only contains sales for
+the year 2024. Because the dataset lacks three full years of history, the
+predicted stock levels produced by PandasAI may not be a reliable estimate of
+future inventory needs.


### PR DESCRIPTION
## Summary
- add required dependencies to `requirements.txt`
- document new PandasAI output in `result.md`

## Testing
- `python -m py_compile app.py`
- `SALES_DATA_CSV=sample_sales.csv python app.py <<'EOF'
3年間の各商品の平均売上個数から、翌年の入荷数を予測してください。
EOF`

------
https://chatgpt.com/codex/tasks/task_e_684d16a8b75883268b10145e9d6ac48b